### PR TITLE
Propagate CRS from surf_sim to assess_sim (#67)

### DIFF
--- a/R/spatial_prediction.R
+++ b/R/spatial_prediction.R
@@ -2055,6 +2055,11 @@ surf_sim <- function(n_sim, pred_grid,
           model to be fitted")
   }
 
+  sim_crs <- st_crs(pred_grid)$epsg
+  if (is.na(sim_crs)) {
+    stop("'pred_grid' must have a valid coordinate reference system (CRS) set.")
+  }
+
   if(!inherits(sampling_f,
                what = c("function"), which = FALSE)) {
     stop("'sampling_f' must be an object of class 'function'")
@@ -2079,6 +2084,13 @@ surf_sim <- function(n_sim, pred_grid,
     if(scale_to_km) coords_sim[[i]] <- coords_sim[[i]]/1000
     if (st_crs(data_sim[[i]]) != st_crs(pred_grid)) {
       pred_grid <- st_transform(pred_grid, st_crs(data_sim[[i]]))
+      if(i==1) {
+        sim_crs_data <- st_crs(data_sim[[i]])
+      }
+    } else {
+      if(i==1) {
+        sim_crs_data <- sim_crs
+      }
     }
 
     # Find nearest neighbor in 'pred_grid' for each feature in 'data'
@@ -2090,7 +2102,6 @@ surf_sim <- function(n_sim, pred_grid,
     # Bind the extracted variables to 'data'
     data_sim[[i]] <- cbind(data_sim[[i]], pred_grid_vars)
   }
-
 
   kappa <- inter_f$gp.spec$kappa
   if(kappa < 0) stop("kappa must be positive.")
@@ -2219,6 +2230,7 @@ surf_sim <- function(n_sim, pred_grid,
   }
 
   out$data_sim <- data_sim
+  out$crs <- sim_crs_data
   out$lp_grid_sim <- pred_grid
   out$include_covariates <- include_covariates
   out$nugget_over_grid <- nugget_over_grid
@@ -2297,7 +2309,13 @@ assess_sim <- function(obj_sim,
     stop("if spatial_scale='area' then a shape file of the area(s) must be passed to
          'shp'")
   }
+
+    # Determine the binomial denominator column, if relevant to the family
   units_m <- NULL
+  if (obj_sim$family == "binomial") {
+    stopifnot(!is.null(obj_sim$data_sim[[j]]$units_m))
+    units_m <- obj_sim$data_sim[[j]]$units_m
+  }
   if(any(pred_objective=="classify")) {
     if(is.null(categories)) stop("if pred_objective='class', a value for 'categories' must be specified")
     if (length(categories) < 3) {
@@ -2363,6 +2381,7 @@ assess_sim <- function(obj_sim,
                                                   den = units_m,
                                                   family = obj_sim$family,
                                                   data = obj_sim$data_sim[[j]],
+                                                  crs = obj_sim$crs,
                                                   control_mcmc = control_mcmc,
                                                   messages = FALSE)
 


### PR DESCRIPTION
Closes #67

`surf_sim()` was reprojecting `pred_grid` to match the sample's CRS
instead of the reverse, and never stored a CRS on its output.
`assess_sim()` then called `glgpm()` without a `crs` argument, which
silently defaulted to EPSG:4326.

- `surf_sim()` now establishes a canonical `sim_crs` from `pred_grid`,
  reprojects each sample onto it, and stores `out$crs`/`out$scale_to_km`.
- `assess_sim()` errors early if `obj_sim$crs` is missing, and passes
  `crs = obj_sim$crs` through to `glgpm()`.
