### PR TITLE
Fix random-effect subsetting for tibble-backed data

### DIFF
--- a/R/mda_modelling.R
+++ b/R/mda_modelling.R
@@ -386,11 +386,10 @@ dast <- function(formula,
 
   # survey_times_data already set from 'time' argument above
 
-  if(length(inter_f$re.spec) > 0) {
-    hr_re <- inter_f$re.spec$term
-    re_names <- inter_f$re.spec$term
+  hr_re <- if (length(inter_f$re.spec) > 0L) {
+    inter_f$re.spec$term
   } else {
-    hr_re <- NULL
+    NULL
   }
   if(!is.null(drop)) {
     fix_alpha <- drop
@@ -398,39 +397,15 @@ dast <- function(formula,
     fix_alpha <- NULL
   }
 
-  if(!is.null(hr_re)) {
-    # Define indices of random effects
-    re_mf <- st_drop_geometry(data[hr_re])
-    re_mf_n <- re_mf
-
-    if(any(is.na(re_mf))) stop("Missing values in the variable(s) of the random effects specified through re() ")
-    names_re <- colnames(re_mf)
-    n_re <- ncol(re_mf)
-
-    ID_re <- matrix(NA, nrow = n, ncol = n_re)
-    re_unique <- list()
-    re_unique_f <- list()
-    for(i in 1:n_re) {
-      if(is.factor(re_mf[,i])) {
-        re_mf_n[,i] <- as.numeric(re_mf[,i])
-        re_unique[[names_re[i]]] <- 1:length(levels(re_mf[,i]))
-        ID_re[, i] <- sapply(1:n,
-                             function(j) which(re_mf_n[j,i]==re_unique[[names_re[i]]]))
-        re_unique_f[[names_re[i]]] <-levels(re_mf[,i])
-      } else if(is.numeric(re_mf[,i])) {
-        re_unique[[names_re[i]]] <- unique(re_mf[,i])
-        ID_re[, i] <- sapply(1:n,
-                             function(j) which(re_mf_n[j,i]==re_unique[[names_re[i]]]))
-        re_unique_f[[names_re[i]]] <- re_unique[[names_re[i]]]
-      }
-    }
-    ID_re <- data.frame(ID_re)
-    colnames(ID_re) <- re_names
-  } else {
-    n_re <- 0
-    re_unique <- NULL
-    ID_re <- NULL
+  random_effects <- prepare_random_effects(data, hr_re)
+  n_re <- random_effects$n_re
+  names_re <- random_effects$names_re
+  ID_re <- random_effects$ID_re
+  if (!is.null(ID_re)) {
+    ID_re <- as.data.frame(ID_re)
   }
+  re_unique <- random_effects$re_unique
+  re_unique_f <- random_effects$re_unique_f
 
 
   # Extract coordinates
@@ -830,44 +805,15 @@ dast_sim <- function(n_sim,
   }
   if (is.null(power_val)) stop("'power_val' must be provided")
 
-  if(length(inter_f$re.spec) > 0) {
-    hr_re <- inter_f$re.spec$term
+  hr_re <- if (length(inter_f$re.spec) > 0L) {
+    inter_f$re.spec$term
   } else {
-    hr_re <- NULL
+    NULL
   }
-
-  if(!is.null(hr_re)) {
-    re_mf <- st_drop_geometry(data[hr_re])
-    re_mf_n <- re_mf
-
-    if(any(is.na(re_mf))) stop("Missing values in the variable(s) of the random effects specified through re()")
-    names_re <- colnames(re_mf)
-    n_re <- ncol(re_mf)
-
-    ID_re <- matrix(NA, nrow = n, ncol = n_re)
-    re_unique <- list()
-    re_unique_f <- list()
-    for(i in 1:n_re) {
-      if(is.factor(re_mf[,i])) {
-        re_mf_n[,i] <- as.numeric(re_mf[,i])
-        re_unique[[names_re[i]]] <- 1:length(levels(re_mf[,i]))
-        ID_re[, i] <- sapply(1:n,
-                             function(j) which(re_mf_n[j,i]==re_unique[[names_re[i]]]))
-        re_unique_f[[names_re[i]]] <-levels(re_mf[,i])
-      } else if(is.numeric(re_mf[,i])) {
-        re_unique[[names_re[i]]] <- unique(re_mf[,i])
-        ID_re[, i] <- sapply(1:n,
-                             function(j) which(re_mf_n[j,i]==re_unique[[names_re[i]]]))
-        re_unique_f[[names_re[i]]] <- re_unique[[names_re[i]]]
-      }
-    }
-    ID_re <- data.frame(ID_re)
-    colnames(ID_re) <- names_re
-  } else {
-    n_re <- 0
-    re_unique <- NULL
-    ID_re <- NULL
-  }
+  random_effects <- prepare_random_effects(data, hr_re)
+  n_re <- random_effects$n_re
+  ID_re <- random_effects$ID_re
+  re_unique <- random_effects$re_unique
 
   if(!is.null(convert_to_crs)) {
     if(!is.numeric(convert_to_crs)) stop("'convert_to_crs' must be a numeric object")

--- a/R/parameter_estimation.R
+++ b/R/parameter_estimation.R
@@ -162,46 +162,20 @@ glgpm <- function(formula,
 
   }
 
-  if(length(inter_f$re.spec) > 0) {
-    hr_re <- inter_f$re.spec$term
-    re_names <- inter_f$re.spec$term
+  hr_re <- if (length(inter_f$re.spec) > 0L) {
+    inter_f$re.spec$term
   } else {
-    hr_re <- NULL
+    NULL
   }
-
-  if(!is.null(hr_re)) {
-    # Define indices of random effects
-    re_mf <- st_drop_geometry(data[hr_re])
-    re_mf_n <- re_mf
-
-    if(any(is.na(re_mf))) stop("Missing values in the variable(s) of the random effects specified through re() ")
-    names_re <- colnames(re_mf)
-    n_re <- ncol(re_mf)
-
-    ID_re <- matrix(NA, nrow = n, ncol = n_re)
-    re_unique <- list()
-    re_unique_f <- list()
-    for(i in 1:n_re) {
-      if(is.factor(re_mf[,i])) {
-        re_mf_n[,i] <- as.numeric(re_mf[,i])
-        re_unique[[names_re[i]]] <- 1:length(levels(re_mf[,i]))
-        ID_re[, i] <- sapply(1:n,
-                             function(j) which(re_mf_n[j,i]==re_unique[[names_re[i]]]))
-        re_unique_f[[names_re[i]]] <-levels(re_mf[,i])
-      } else if(is.numeric(re_mf[,i])) {
-        re_unique[[names_re[i]]] <- unique(re_mf[,i])
-        ID_re[, i] <- sapply(1:n,
-                             function(j) which(re_mf_n[j,i]==re_unique[[names_re[i]]]))
-        re_unique_f[[names_re[i]]] <- re_unique[[names_re[i]]]
-      }
-    }
-    ID_re <- data.frame(ID_re)
-    colnames(ID_re) <- re_names
-  } else {
-    n_re <- 0
-    re_unique <- NULL
-    ID_re <- NULL
+  random_effects <- prepare_random_effects(data, hr_re)
+  n_re <- random_effects$n_re
+  names_re <- random_effects$names_re
+  ID_re <- random_effects$ID_re
+  if (!is.null(ID_re)) {
+    ID_re <- as.data.frame(ID_re)
   }
+  re_unique <- random_effects$re_unique
+  re_unique_f <- random_effects$re_unique_f
 
 
   # Extract coordinates
@@ -1360,44 +1334,15 @@ glgpm_sim <- function(n_sim,
   D <- as.matrix(model.matrix(attr(mf,"terms"),data=data))
   n <- nrow(D)
 
-  if(length(inter_f$re.spec) > 0) {
-    hr_re <- inter_f$re.spec$term
+  hr_re <- if (length(inter_f$re.spec) > 0L) {
+    inter_f$re.spec$term
   } else {
-    hr_re <- NULL
+    NULL
   }
-
-
-  if(!is.null(hr_re)) {
-    # Define indices of random effects
-    re_mf <- st_drop_geometry(data[hr_re])
-    re_mf_n <- re_mf
-
-    if(any(is.na(re_mf))) stop("Missing values in the variable(s) of the random effects specified through re() ")
-    names_re <- colnames(re_mf)
-    n_re <- ncol(re_mf)
-
-    ID_re <- matrix(NA, nrow = n, ncol = n_re)
-    re_unique <- list()
-    re_unique_f <- list()
-    for(i in 1:n_re) {
-      if(is.factor(re_mf[,i])) {
-        re_mf_n[,i] <- as.numeric(re_mf[,i])
-        re_unique[[names_re[i]]] <- 1:length(levels(re_mf[,i]))
-        ID_re[, i] <- sapply(1:n,
-                             function(j) which(re_mf_n[j,i]==re_unique[[names_re[i]]]))
-        re_unique_f[[names_re[i]]] <-levels(re_mf[,i])
-      } else if(is.numeric(re_mf[,i])) {
-        re_unique[[names_re[i]]] <- unique(re_mf[,i])
-        ID_re[, i] <- sapply(1:n,
-                             function(j) which(re_mf_n[j,i]==re_unique[[names_re[i]]]))
-        re_unique_f[[names_re[i]]] <- re_unique[[names_re[i]]]
-      }
-    }
-  } else {
-    n_re <- 0
-    re_unique <- NULL
-    ID_re <- NULL
-  }
+  random_effects <- prepare_random_effects(data, hr_re)
+  n_re <- random_effects$n_re
+  ID_re <- random_effects$ID_re
+  re_unique <- random_effects$re_unique
 
   # Number of covariates
   p <- ncol(D)

--- a/R/random_effects.R
+++ b/R/random_effects.R
@@ -1,0 +1,109 @@
+##' Prepare Random-Effect Group Indices
+##'
+##' Extracts grouping variables from a data-frame-like object and converts
+##' their values to the internal indices used by RiskMap model-fitting and
+##' simulation functions.
+##'
+##' @param data A data-frame-like object containing the grouping variables.
+##' @param terms A character vector naming the grouping variables.
+##'
+##' @return A list containing the number and names of random effects, their
+##'   observation-level indices, internal level indices, and display labels.
+##'
+##' @noRd
+prepare_random_effects <- function(data, terms) {
+  if (is.null(terms)) {
+    result <- list(
+      n_re = 0L,
+      names_re = NULL,
+      ID_re = NULL,
+      re_unique = NULL,
+      re_unique_f = NULL
+    )
+    class(result) <- "RiskMap_random_effects"
+    return(result)
+  }
+
+  missing_terms <- setdiff(terms, names(data))
+  if (length(missing_terms) > 0L) {
+    stop(
+      "Random-effect variable(s) not found in `data`: ",
+      paste(missing_terms, collapse = ", "),
+      "."
+    )
+  }
+
+  encoded_groups <- lapply(
+    terms,
+    function(term) encode_random_effect(data[[term]], term)
+  )
+  names(encoded_groups) <- terms
+
+  ID_re <- matrix(
+    unlist(
+      lapply(encoded_groups, function(group) group$ids),
+      use.names = FALSE
+    ),
+    nrow = nrow(data),
+    ncol = length(terms),
+    dimnames = list(NULL, terms)
+  )
+
+  result <- list(
+    n_re = length(terms),
+    names_re = terms,
+    ID_re = ID_re,
+    re_unique = lapply(encoded_groups, function(group) group$indices),
+    re_unique_f = lapply(encoded_groups, function(group) group$labels)
+  )
+  class(result) <- "RiskMap_random_effects"
+  result
+}
+
+##' Encode a Random-Effect Grouping Variable
+##'
+##' @param group A factor, character, integer, or numeric grouping vector.
+##' @param variable_name A character string naming the grouping variable.
+##'
+##' @return A list containing observation-level indices, internal level
+##'   indices, and original display labels.
+##'
+##' @noRd
+encode_random_effect <- function(group, variable_name) {
+  if (anyNA(group)) {
+    stop(
+      "Random-effect variable `", variable_name,
+      "` contains missing values."
+    )
+  }
+
+  if (is.factor(group)) {
+    labels <- levels(group)
+    ids <- as.integer(group)
+  } else if (is.character(group)) {
+    labels <- unique(group)
+    ids <- match(group, labels)
+  } else if (is.numeric(group)) {
+    if (any(!is.finite(group))) {
+      stop(
+        "Random-effect variable `", variable_name,
+        "` contains non-finite values."
+      )
+    }
+    labels <- unique(group)
+    ids <- match(group, labels)
+  } else {
+    stop(
+      "Random-effect variable `", variable_name,
+      "` must be a factor, character, integer, or numeric vector."
+    )
+  }
+
+  result <- list(
+    ids = as.integer(ids),
+    indices = seq_along(labels),
+    labels = labels
+  )
+  class(result) <- "RiskMap_random_effect"
+  result
+}

--- a/tests/testthat/test-random-effects.R
+++ b/tests/testthat/test-random-effects.R
@@ -1,0 +1,220 @@
+test_that("random effects are encoded consistently across data containers", {
+  base_data <- data.frame(
+    region = factor(
+      c("north", "south", "north", "south"),
+      levels = c("north", "south", "unused")
+    ),
+    province = c(10, 30, 10, 20),
+    x = seq_len(4),
+    y = seq_len(4)
+  )
+  tibble_data <- tibble::as_tibble(base_data)
+  sf_data <- sf::st_as_sf(
+    base_data,
+    coords = c("x", "y"),
+    crs = 32634
+  )
+  sf_tibble <- sf::st_as_sf(
+    tibble_data,
+    coords = c("x", "y"),
+    crs = 32634
+  )
+
+  expected <- RiskMap:::prepare_random_effects(
+    base_data,
+    c("region", "province")
+  )
+
+  expect_equal(
+    RiskMap:::prepare_random_effects(tibble_data, c("region", "province")),
+    expected
+  )
+  expect_equal(
+    RiskMap:::prepare_random_effects(sf_data, c("region", "province")),
+    expected
+  )
+  expect_equal(
+    RiskMap:::prepare_random_effects(sf_tibble, c("region", "province")),
+    expected
+  )
+  expect_equal(
+    expected$ID_re,
+    matrix(
+      c(1L, 2L, 1L, 2L, 1L, 2L, 1L, 3L),
+      ncol = 2L,
+      dimnames = list(NULL, c("region", "province"))
+    )
+  )
+  expect_equal(expected$re_unique$region, seq_len(3))
+  expect_equal(expected$re_unique_f$region, c("north", "south", "unused"))
+  expect_equal(expected$re_unique$province, seq_len(3))
+  expect_equal(expected$re_unique_f$province, c(10, 30, 20))
+})
+
+test_that("supported random-effect types retain their labels and ordering", {
+  data <- data.frame(
+    ordered_group = ordered(
+      c("medium", "low", "high"),
+      levels = c("low", "medium", "high")
+    ),
+    character_group = c("beta", "alpha", "beta"),
+    integer_group = c(20L, 10L, 20L)
+  )
+
+  result <- RiskMap:::prepare_random_effects(
+    data,
+    c("ordered_group", "character_group", "integer_group")
+  )
+
+  expect_equal(result$ID_re[, "ordered_group"], c(2L, 1L, 3L))
+  expect_equal(
+    result$re_unique_f$ordered_group,
+    c("low", "medium", "high")
+  )
+  expect_equal(result$ID_re[, "character_group"], c(1L, 2L, 1L))
+  expect_equal(result$re_unique_f$character_group, c("beta", "alpha"))
+  expect_equal(result$ID_re[, "integer_group"], c(1L, 2L, 1L))
+  expect_equal(result$re_unique_f$integer_group, c(20L, 10L))
+})
+
+test_that("a single random effect retains a matrix index", {
+  result <- RiskMap:::prepare_random_effects(
+    data.frame(group = factor(c("a", "b", "a"))),
+    "group"
+  )
+
+  expect_equal(dim(result$ID_re), c(3L, 1L))
+  expect_equal(colnames(result$ID_re), "group")
+  expect_equal(result$ID_re[, 1], c(1L, 2L, 1L))
+})
+
+test_that("one-row data retain all random-effect columns", {
+  result <- RiskMap:::prepare_random_effects(
+    data.frame(
+      region = factor("north"),
+      province = 10
+    ),
+    c("region", "province")
+  )
+
+  expect_equal(dim(result$ID_re), c(1L, 2L))
+  expect_equal(colnames(result$ID_re), c("region", "province"))
+  expect_equal(result$ID_re[1, ], c(region = 1L, province = 1L))
+})
+
+test_that("no random effects return the established null representation", {
+  result <- RiskMap:::prepare_random_effects(data.frame(value = 1:3), NULL)
+
+  expect_equal(result$n_re, 0L)
+  expect_null(result$names_re)
+  expect_null(result$ID_re)
+  expect_null(result$re_unique)
+  expect_null(result$re_unique_f)
+})
+
+test_that("invalid random-effect variables fail informatively", {
+  expect_error(
+    RiskMap:::prepare_random_effects(
+      data.frame(group = c("a", NA)),
+      "group"
+    ),
+    "contains missing values",
+    fixed = TRUE
+  )
+  expect_error(
+    RiskMap:::prepare_random_effects(
+      data.frame(group = c(1, Inf)),
+      "group"
+    ),
+    "contains non-finite values",
+    fixed = TRUE
+  )
+  expect_error(
+    RiskMap:::prepare_random_effects(
+      data.frame(group = c(TRUE, FALSE)),
+      "group"
+    ),
+    "must be a factor, character, integer, or numeric vector",
+    fixed = TRUE
+  )
+  expect_error(
+    RiskMap:::prepare_random_effects(data.frame(value = 1:2), "group"),
+    "not found in `data`",
+    fixed = TRUE
+  )
+})
+
+test_that("glgpm simulations support random effects in tibble-backed sf data", {
+  data <- tibble::tibble(
+    y = 0,
+    group = factor(c("a", "a", "b", "b")),
+    x = c(0, 1, 0, 1),
+    z = c(0, 0, 1, 1)
+  )
+  data <- sf::st_as_sf(data, coords = c("x", "z"), crs = 32634)
+
+  set.seed(1)
+  result <- suppressWarnings(
+    glgpm_sim(
+      n_sim = 2,
+      formula = y ~ gp(kappa = 0.5, nugget = 0) + re(group),
+      data = data,
+      family = "gaussian",
+      sim_pars = list(
+        beta = 0,
+        sigma2 = 1,
+        tau2 = 0,
+        phi = 1,
+        sigma2_me = 0.1,
+        sigma2_re = 0.2
+      ),
+      messages = FALSE
+    )
+  )
+
+  expect_length(result$re_sim, 2L)
+  expect_length(result$re_sim[[1]]$group, 2L)
+  expect_equal(result$sigma2_re, 0.2)
+})
+
+test_that("dast simulations support random effects in tibble-backed sf data", {
+  data <- tibble::tibble(
+    y = c(1, 2, 1, 2),
+    m = rep(10, 4),
+    survey_time = seq_len(4),
+    group = factor(c("a", "a", "b", "b")),
+    x = c(0, 1, 0, 1),
+    z = c(0, 0, 1, 1)
+  )
+  data <- sf::st_as_sf(data, coords = c("x", "z"), crs = 32634)
+  m <- data$m
+
+  set.seed(1)
+  result <- suppressWarnings(
+    dast_sim(
+      n_sim = 2,
+      formula = y ~ gp(kappa = 0.5, nugget = 0) + re(group),
+      data = data,
+      den = m,
+      time = "survey_time",
+      mda_times = 2,
+      int_mat = matrix(0, nrow = 4, ncol = 1),
+      power_val = 1,
+      sim_pars = list(
+        beta = 0,
+        sigma2 = 1,
+        tau2 = 0,
+        phi = 1,
+        psi = NULL,
+        sigma2_re = 0.2,
+        alpha = 0.1,
+        gamma = 0.2
+      ),
+      messages = FALSE
+    )
+  )
+
+  expect_length(result$re_sim, 2L)
+  expect_length(result$re_sim[[1]]$group, 2L)
+  expect_equal(result$sigma2_re, 0.2)
+})


### PR DESCRIPTION
## Summary

- centralize random-effect group encoding in a documented internal helper
- extract grouping columns with `[[` so data frames, tibbles, and `sf` objects behave consistently
- reuse the encoder in `glgpm()`, `glgpm_sim()`, `dast()`, and `dast_sim()`
- add defensive validation and focused regression coverage

## Root cause

RiskMap's packaged datasets were normalized to tibbles, but the random-effect parser used `re_mf[, i]`. Tibble subsetting returns a one-column tibble rather than a vector, so both `is.factor()` and `is.numeric()` returned false. This left `re_unique` empty and `ID_re` missing before `glgpm_lm()` attempted to index `re_unique[[j]]`.

The new encoder uses direct `data[[term]]` extraction and `match()` to create contiguous internal IDs while preserving original labels and established factor-level ordering. The downstream structures consumed by fitting and simulation code remain unchanged.

## User impact

Tibble-backed `sf` inputs now support factor, ordered-factor, character, integer, and numeric random-effect identifiers. Invalid, missing, or non-finite grouping values fail with informative errors.

## Validation

- `devtools::test()`: 83 passed, 0 failed, 0 warnings, 0 skipped
- exact Italy book model: 2,000 rows; 19 regions; 78 provinces; established estimates reproduced
- `devtools::check(document = FALSE, error_on = "warning")`: 0 errors, 0 warnings
- four existing/environmental notes remain: worktree `.git`, clock verification, existing license stub, and existing `Sigma_cond` global binding

Fixes #40