### PR TITLE
65 check shp

### DIFF
--- a/R/auxiliary.R
+++ b/R/auxiliary.R
@@ -1466,19 +1466,24 @@ check_binomial <- function(y, den){
 #' @title check_data
 #' @description
 #'
-#' Check that the data is an sf object, with a CRS, only containing points and if
-#' CRS == 4326 that the coordinates are possible (i.e. not latitudes > 90)
+#' Check that the data is an sf object, with a CRS, only containing points
+#' or either polygons or multipolygons. If CRS == 4326 it also checks that the #
+#' coordinates are possible (i.e. not latitudes > 90)
 #' @param data the data to check
-#' @param type whether to check that the data contains 'point' (default) or
-#' 'polygon'
+#' @param geometry whether to check that the data contains 'point' (default) or
+#' 'polygon' (covering both polygons and multipolygons)
 #' @return TRUE if the data is valid. Raise an error if not.
 #' @noRd
 #'
-check_data <- function(data, type = "point"){
-  stopifnot("'type' must be either 'point' or 'polygon'" = type %in% c("point", "polygon"))
-  data_type <- switch(type,
+check_data <- function(data, geometry = "point"){
+  stopifnot("'geometry' must be either 'point' or 'polygon'" = geometry %in% c("point", "polygon"))
+  data_type <- switch(geometry,
                       point = "'data'",
                       polygon = "'shp'")
+
+  geometry_type <- switch(geometry,
+                          point = "'POINT'",
+                          polygon = "'POLYGON' or 'MULTIPOLYGON'")
 
   if (!inherits(data, "sf")){
     stop(paste(data_type, "must be of class 'sf'"))
@@ -1488,9 +1493,9 @@ check_data <- function(data, type = "point"){
     stop(paste(data_type, "must contain a coordinate reference system"))
   }
 
-  all_valid_type <- all(sf::st_geometry_type(data) == toupper(type))
-  if (!all_valid_type){
-    stop(paste(data_type, "can only contain", type, "geometry"))
+  all_valid_geometry <- all(grepl(toupper(geometry), sf::st_geometry_type(data)))
+  if (!all_valid_geometry){
+    stop(paste(data_type, "can only contain", geometry_type, "geometry"))
   }
 
   if (sf::st_crs(data) == sf::st_crs(4326)){

--- a/R/auxiliary.R
+++ b/R/auxiliary.R
@@ -1476,18 +1476,29 @@ check_binomial <- function(y, den){
 #'
 check_data <- function(data, type = "point"){
   stopifnot("'type' must be either 'point' or 'polygon'" = type %in% c("point", "polygon"))
-  stopifnot("'data' must be of class 'sf'" = inherits(data, "sf"))
-  stopifnot("'data' must contain a coordinate reference system" = !is.na(sf::st_crs(data)))
+  data_type <- switch(type,
+                      point = "'data'",
+                      polygon = "'shp'")
+
+  if (!inherits(data, "sf")){
+    stop(paste(data_type, "must be of class 'sf'"))
+  }
+
+  if (is.na(sf::st_crs(data))){
+    stop(paste(data_type, "must contain a coordinate reference system"))
+  }
+
   all_valid_type <- all(sf::st_geometry_type(data) == toupper(type))
   if (!all_valid_type){
-    stop(paste("'data' can only contain", type, "geometry"))
+    stop(paste(data_type, "can only contain", type, "geometry"))
   }
+
   if (sf::st_crs(data) == sf::st_crs(4326)){
     tryCatch(
       sf::st_is_longlat(data$geometry),
       warning = function(w) {
-        stop("'data' contains impossible latitude or longitude values -
-             check you have specified the columns correctly when converting the data")
+        stop(paste(data_type, "contains impossible latitude or longitude values -
+             check you have specified the columns correctly when converting the data"))
       }
     )
   }

--- a/R/auxiliary.R
+++ b/R/auxiliary.R
@@ -1469,14 +1469,19 @@ check_binomial <- function(y, den){
 #' Check that the data is an sf object, with a CRS, only containing points and if
 #' CRS == 4326 that the coordinates are possible (i.e. not latitudes > 90)
 #' @param data the data to check
+#' @param type whether to check that the data contains 'point' (default) or
+#' 'polygon'
 #' @return TRUE if the data is valid. Raise an error if not.
 #' @noRd
 #'
-check_data <- function(data){
+check_data <- function(data, type = "point"){
+  stopifnot("'type' must be either 'point' or 'polygon'" = type %in% c("point", "polygon"))
   stopifnot("'data' must be of class 'sf'" = inherits(data, "sf"))
   stopifnot("'data' must contain a coordinate reference system" = !is.na(sf::st_crs(data)))
-  all_points <- all(sf::st_geometry_type(data) == "POINT")
-  stopifnot("'data' can only contain point geometry" = all_points)
+  all_valid_type <- all(sf::st_geometry_type(data) == toupper(type))
+  if (!all_valid_type){
+    stop(paste("'data' can only contain", type, "geometry"))
+  }
   if (sf::st_crs(data) == sf::st_crs(4326)){
     tryCatch(
       sf::st_is_longlat(data$geometry),

--- a/R/handling_spat_data.R
+++ b/R/handling_spat_data.R
@@ -37,9 +37,7 @@
 create_grid <- function(shp, spat_res,
                         grid_crs = NULL) {
 
-  if(!inherits(shp, "sf")) stop("'shp' must be an object of class 'sf'")
-
-  if(is.na(st_crs(shp))) stop("The CRS for 'shp' is missing")
+  check_data(shp, "polygon")
 
   if(is.null(grid_crs)) {
     grid_crs <- st_crs(shp)

--- a/R/spatial_prediction.R
+++ b/R/spatial_prediction.R
@@ -900,6 +900,8 @@ pred_target_shp <- function(object, shp, shp_target = mean,
          rerun 'pred_over_grid' and set type='joint'")
   }
 
+  check_data(shp, "polygon")
+
   dast_model <- !is.null(object$par_hat$gamma)
 
   if(dast_model) {
@@ -2308,6 +2310,8 @@ assess_sim <- function(obj_sim,
     stop("if spatial_scale='area' then a shape file of the area(s) must be passed to
          'shp'")
   }
+
+  check_data(shp, "polygon")
 
     # Determine the binomial denominator column, if relevant to the family
   units_m <- NULL

--- a/tests/testthat/test-auxiliary.R
+++ b/tests/testthat/test-auxiliary.R
@@ -36,6 +36,6 @@ test_that("check_data functions correctly", {
   expect_error(check_data(sf_wrong_coord), "'data' contains impossible latitude or longitude values")
 
   expect_no_error(check_data(sf_polygon, "polygon"))
-  expect_error(check_data(sf_data, "polygon"), "'data' can only contain polygon geometry")
-  expect_error(check_data(sf_merged, "polygon"), "'data' can only contain polygon geometry")
+  expect_error(check_data(sf_data, "polygon"), "'shp' can only contain polygon geometry")
+  expect_error(check_data(sf_merged, "polygon"), "'shp' can only contain polygon geometry")
 })

--- a/tests/testthat/test-auxiliary.R
+++ b/tests/testthat/test-auxiliary.R
@@ -24,18 +24,23 @@ test_that("check_data functions correctly", {
   sf_wrong_coord <- sf::st_as_sf(data, coords = c("x", "y"), crs = sf::st_crs(4326))
 
   polygon <- sf::st_polygon(list(matrix(c(4,4, 5,4, 5,5, 4,5, 4,4), ncol = 2, byrow = TRUE)))
+  multipolygon <- sf::st_multipolygon(list(polygon))
   sf_polygon <- sf::st_sf(z = 3, geometry = sf::st_sfc(polygon), crs = sf::st_crs(4326))
+  sf_multipolygon <- sf::st_sf(z = 3, geometry = sf::st_sfc(multipolygon), crs = sf::st_crs(4326))
   sf_merged <- rbind(sf_data, sf_polygon)
 
-  expect_error(check_data(sf_data, "n"), "'type' must be either 'point' or 'polygon'")
+  expect_error(check_data(sf_data, "n"), "'geometry' must be either 'point' or 'polygon'")
 
   expect_no_error(check_data(sf_data))
   expect_error(check_data(data), "'data' must be of class 'sf'")
   expect_error(check_data(sf_no_crs), "'data' must contain a coordinate reference system")
-  expect_error(check_data(sf_merged), "'data' can only contain point geometry")
+  expect_error(check_data(sf_merged), "'data' can only contain 'POINT' geometry")
   expect_error(check_data(sf_wrong_coord), "'data' contains impossible latitude or longitude values")
 
   expect_no_error(check_data(sf_polygon, "polygon"))
-  expect_error(check_data(sf_data, "polygon"), "'shp' can only contain polygon geometry")
-  expect_error(check_data(sf_merged, "polygon"), "'shp' can only contain polygon geometry")
+  expect_error(check_data(sf_data, "polygon"), "'shp' can only contain 'POLYGON' or 'MULTIPOLYGON' geometry")
+  expect_error(check_data(sf_merged, "polygon"), "'shp' can only contain 'POLYGON' or 'MULTIPOLYGON' geometry")
+
+  expect_no_error(check_data(sf_multipolygon, "polygon"))
+
 })

--- a/tests/testthat/test-auxiliary.R
+++ b/tests/testthat/test-auxiliary.R
@@ -33,4 +33,7 @@ test_that("check_data functions correctly", {
   expect_error(check_data(sf_merged), "'data' can only contain point geometry")
   expect_error(check_data(sf_wrong_coord), "'data' contains impossible latitude or longitude values")
 
+  expect_no_error(check_data(sf_polygon, "polygon"))
+  expect_error(check_data(sf_data, "polygon"), "'data' can only contain polygon geometry")
+  expect_error(check_data(sf_merged, "polygon"), "'data' can only contain polygon geometry")
 })

--- a/tests/testthat/test-auxiliary.R
+++ b/tests/testthat/test-auxiliary.R
@@ -27,10 +27,15 @@ test_that("check_data functions correctly", {
   sf_polygon <- sf::st_sf(z = 3, geometry = sf::st_sfc(polygon), crs = sf::st_crs(4326))
   sf_merged <- rbind(sf_data, sf_polygon)
 
+  expect_error(check_data(sf_data, "n"), "'type' must be either 'point' or 'polygon'")
+
   expect_no_error(check_data(sf_data))
   expect_error(check_data(data), "'data' must be of class 'sf'")
   expect_error(check_data(sf_no_crs), "'data' must contain a coordinate reference system")
   expect_error(check_data(sf_merged), "'data' can only contain point geometry")
   expect_error(check_data(sf_wrong_coord), "'data' contains impossible latitude or longitude values")
 
+  expect_no_error(check_data(sf_polygon, "polygon"))
+  expect_error(check_data(sf_data, "polygon"), "'data' can only contain polygon geometry")
+  expect_error(check_data(sf_merged, "polygon"), "'data' can only contain polygon geometry")
 })

--- a/tests/testthat/test-pred_target_grid.R
+++ b/tests/testthat/test-pred_target_grid.R
@@ -38,10 +38,12 @@ test_that("pred_target_shp preserves posterior samples for one-pixel list-mode r
     group_one = sf::st_as_sf(data.frame(x = 0, y = 0), coords = c("x", "y"), crs = 4326),
     group_two = sf::st_as_sf(data.frame(x = c(1, 2), y = c(1, 2)), coords = c("x", "y"), crs = 4326)
   )
-  shp <- sf::st_sf(
-    region = c("group_one", "group_two"),
-    geometry = sf::st_sfc(sf::st_point(c(0, 0)), sf::st_point(c(1, 1)), crs = 4326)
-  )
+
+  polygon_1 <- sf::st_polygon(list(matrix(c(0,0, 0.1,0, 0.1,0.1, 0,0.1, 0,0), ncol = 2, byrow = TRUE)))
+  polygon_2 <- sf::st_polygon(list(matrix(c(1,1, 1.5,1, 1.5,1.5, 1,1.5, 1,1), ncol = 2, byrow = TRUE)))
+  shp <- sf::st_sf(region = c("group_one", "group_two"),
+                          geometry = sf::st_sfc(polygon_1, polygon_2), crs = sf::st_crs(4326))
+
   object <- list(
     type = "joint",
     grid_pred = grid_pred,
@@ -81,7 +83,7 @@ test_that("pred_target_shp errors on wrong list-mode target orientation", {
   )
   shp <- sf::st_sf(
     region = "group_one",
-    geometry = sf::st_sfc(sf::st_point(c(0, 0)), crs = 4326)
+    geometry = sf::st_sfc(sf::st_polygon(list(matrix(c(0,0, 0.1,0, 0.1,0.1, 0,0.1, 0,0), ncol = 2, byrow = TRUE))), crs = 4326)
   )
   object <- list(
     type = "joint",


### PR DESCRIPTION
@claudiofronterre The tests for `pred_target_shp` are failing because the `shp` are points. From my reading of the docs, this shouldn't be supported: 

> An sf polygon object (preferred) or a data.frame with an attached geometry column, representing regions over which predictions are aggregated.

Just wanted to check I have misunderstood though before changing the tests.